### PR TITLE
Upgrade to gtk4 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["graphics", "gtk", "opengl", "glium", "gui"]
 categories = ["api-bindings", "graphics", "gui", "rendering", "rendering::graphics-api"]
 
 [dependencies]
-glib = "^0.18.0"
-glium = "^0.33.0"
-gl_loader = "^0.1.2"
-gtk4 = "^0.7.0"
+glib = "0.19.0"
+glium = "0.34.0"
+gl_loader = "0.1.2"
+gtk4 = "0.8.0"


### PR DESCRIPTION
Thanks for this handy little library. It provides some convenience and a gentler introduction to OpenGL in GTK4 :)

Since `gtk4 0.8` is out I thought I'd submit a PR to update all the dependencies to use the latest versions.

I also removed the `^` sign in the version since caret requirement [is the default](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements) and it makes no difference to add it. I can revert that if you prefer being explicit on caret versioning.

I have tried this and it still works fine on my machine (Linux) after the upgrades.