### PR TITLE
Disable default features on glium

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ categories = ["api-bindings", "graphics", "gui", "rendering", "rendering::graphi
 
 [dependencies]
 glib = "0.19.0"
-glium = "0.34.0"
+glium = { version = "0.34.0", default-features = false }
 gl_loader = "0.1.2"
 gtk4 = "0.8.0"


### PR DESCRIPTION
Default features in cargo were a mistake IMO. Lots of library crates take the liberty of deciding that having a huge dependency tree is better than needing to type a little `features = [...]` in `Cargo.toml` as a library consumer. And then when other libraries depend on them they just do the simplest import and end up with loads of transitive dependencies they will never use.

The result in this case is that in order to use `gtk4-glium` I will unavoidably get a lot of dependencies in my dependency tree that neither I, nor `gtk4-glium` ever use.

I here disable all default glium features. `gtk4-glium` itself does not use them. And any user of `gtk4-glium` will import `glium` themselves, so if they need the features they can enable them by themselves.