### PR TITLE
Update from deprecated gtk4 apis to newer ones.

### DIFF
--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -95,7 +95,7 @@ fn main() {
         rows.append(&glarea);
         rows.append(&rotation);
         window.set_child(Some(&rows));
-        window.show();
+        window.set_visible(true);
 
         let facade = GtkFacade::from_glarea(&glarea).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,14 +22,15 @@ unsafe impl Backend for GLAreaBackend {
     }
 
     fn get_framebuffer_dimensions(&self) -> (u32, u32) {
-        let allocation = self.glarea.allocation();
+        let width = self.glarea.width();
+        let height = self.glarea.height();
 
         // On high-resolution screens, the number of pixels in the frame buffer
         // is higher than the allocation. This is indicated by the scale
         // factor.
         let scale = self.glarea.scale_factor();
 
-        ((allocation.width() * scale) as u32, (allocation.height() * scale) as u32)
+        ((width * scale) as u32, (height * scale) as u32)
     }
 
     fn resize(&self, _: (u32, u32)) {


### PR DESCRIPTION
The deprecation warnings are not noticeable when building this library and examples itself. Because it does not activate newer gtk4 features. But if you do, you see that some methods are deprecated. This PR updates these to use the non-deprecated APIs

https://gtk-rs.org/gtk4-rs/stable/0.8/docs/gtk4/prelude/trait.WidgetExt.html#method.show
https://gtk-rs.org/gtk4-rs/stable/0.8/docs/gtk4/prelude/trait.WidgetExt.html#method.allocation